### PR TITLE
Fix: React rules shouldn't be in the base config

### DIFF
--- a/base.js
+++ b/base.js
@@ -1,8 +1,7 @@
 module.exports = {
   extends: [
       'eslint-config-rapid7/legacy',
-      'eslint-config-rapid7/rules/es6',
-      'eslint-config-rapid7/rules/react'
+      'eslint-config-rapid7/rules/es6'
   ].map(require.resolve),
   rules: {}
 };

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 module.exports = {
   extends: [
       'eslint-config-airbnb',
+      'eslint-config-rapid7/rules/react',
       'eslint-config-rapid7/base'
   ].map(require.resolve),
   rules: {}

--- a/package.json
+++ b/package.json
@@ -1,5 +1,4 @@
 {
-
   "author": {
     "name": "Ben Tesser",
     "email": "btesser@rapid7.com"
@@ -52,5 +51,5 @@
     "type": "git",
     "url": "git+https://github.com/rapid7/eslint-config-rapid7.git"
   },
-  "version": "1.0.0"
+  "version": "1.1.0"
 }

--- a/package.json
+++ b/package.json
@@ -1,11 +1,20 @@
 {
-  "author": "Tony Quetano <tquetano@rapid7.com>",
+  "author": {
+    "name": "Tony Quetano",
+    "email": "tony_quetano@rapid7.com"
+  },
   "bugs": {
     "url": "https://github.com/rapid7/esling-config-rapid7/issues"
   },
   "contributors": [
-    "Tony Quetano <tquetano@rapid7.com>",
-    "David Greene <dgreene@rapid7.com>"
+    {
+      "name": "Tony Quetano",
+      "email": "tony_quetano@rapid7.com"
+    },
+    {
+      "name": "David Greene",
+      "email": "david_greene@rapid7.com"
+    }
   ],
   "dependencies": {
     "eslint-config-airbnb": "8.0.0",

--- a/package.json
+++ b/package.json
@@ -1,16 +1,11 @@
 {
-  "author": {
-    "name": "Ben Tesser",
-    "email": "btesser@rapid7.com"
-  },
+  "author": "Tony Quetano <tquetano@rapid7.com>",
   "bugs": {
     "url": "https://github.com/rapid7/esling-config-rapid7/issues"
   },
   "contributors": [
-    {
-      "name": "Ben Tesser",
-      "email": "btesser@rapid7.com"
-    }
+    "Tony Quetano <tquetano@rapid7.com>",
+    "David Greene <dgreene@rapid7.com>"
   ],
   "dependencies": {
     "eslint-config-airbnb": "8.0.0",


### PR DESCRIPTION
Per the readme, the base config shouldn't lint React. Moved the react ruleset out of base and into index.