### PR TITLE
Node rules

### DIFF
--- a/node.js
+++ b/node.js
@@ -1,7 +1,6 @@
 module.exports = {
   extends: [
     'eslint-config-rapid7/rules/node',
-    'eslint-config-rapid7/rules/react',
     'eslint-config-rapid7/base'
   ].map(require.resolve),
   env: {

--- a/rules/node.js
+++ b/rules/node.js
@@ -23,13 +23,13 @@ module.exports = {
     sourceType: 'script'
   },
   rules: {
+    'prefer-spread': 0,
     strict: [2, 'global'],
     'block-spacing': [1, 'always'],
     indent: [1, 2],
     'linebreak-style': [1, 'unix'],
     'no-trailing-spaces': 1,
     'no-irregular-whitespace': 1,
-    'prefer-spread': 0,
     'require-jsdoc': [1, {
       require: {
         FunctionDeclaration: true,

--- a/rules/node.js
+++ b/rules/node.js
@@ -1,9 +1,15 @@
 /*
 * NodeJS 4.x:
-* * Supports CommonJS module/require
-* * Does not support import/export
-* * Does not support JSX (a browser-targeted feature)
-* * Does not support destructuring or spread operators
+* - Supports CommonJS module/require
+* - Does not support import/export
+* - Does not support destructuring or spread operators
+* - Requires global `strict` mode for class and block-scoped declarations
+*
+* Notes:
+* - UNIX whitespace is desired to ensure correct parsing on all
+*   platforms. NodeJS-target JavaScript needs to be evaluated by a shell
+*   when an executable script has a shebang header, and `\m` whitespace can
+*   break this in strange ways.
 */
 module.exports = {
   env: {
@@ -17,14 +23,13 @@ module.exports = {
     sourceType: 'script'
   },
   rules: {
-    'arrow-body-style': 0,
+    strict: [2, 'global'],
     'block-spacing': [1, 'always'],
     indent: [1, 2],
     'linebreak-style': [1, 'unix'],
     'no-trailing-spaces': 1,
     'no-irregular-whitespace': 1,
     'prefer-spread': 0,
-    strict: [2, 'global'],
     'require-jsdoc': [1, {
       require: {
         FunctionDeclaration: true,

--- a/rules/node.js
+++ b/rules/node.js
@@ -24,6 +24,7 @@ module.exports = {
     'linebreak-style': [1, 'unix'],
     'no-trailing-spaces': 1,
     'no-irregular-whitespace': 1,
+    'prefer-spread': 0,
     strict: [2, 'global'],
     'require-jsdoc': [1, {
       require: {

--- a/rules/node.js
+++ b/rules/node.js
@@ -1,6 +1,36 @@
+/*
+* NodeJS 4.x:
+* * Supports CommonJS module/require
+* * Does not support import/export
+* * Does not support JSX (a browser-targeted feature)
+* * Does not support destructuring or spread operators
+*/
 module.exports = {
   env: {
     node: true
   },
-  rules: {}
+  parserOptions: {
+    ecmaFeatures: {
+      globalReturn: false,
+      jsx: false,
+      experimentalObjectRestSpread: false
+    },
+    sourceType: 'script'
+  },
+  rules: {
+    'arrow-body-style': 0,
+    'block-spacing': [1, 'always'],
+    indent: [1, 2],
+    'linebreak-style': [1, 'unix'],
+    'no-trailing-spaces': 1,
+    'no-irregular-whitespace': 1,
+    strict: [2, 'global'],
+    'require-jsdoc': [1, {
+      require: {
+        FunctionDeclaration: true,
+        MethodDefinition: true,
+        ClassDeclaration: true
+      }
+    }]
+  }
 };

--- a/rules/node.js
+++ b/rules/node.js
@@ -12,7 +12,6 @@ module.exports = {
   parserOptions: {
     ecmaFeatures: {
       globalReturn: false,
-      jsx: false,
       experimentalObjectRestSpread: false
     },
     sourceType: 'script'


### PR DESCRIPTION
* Remove JSX profile and disallow JSX
* Set sourceType to script. NodeJS 4.x does not support import/export module definition
* Do not require braces for one-line arrow functions, do require space inside of braces
* Require 2-space indentation, UNIX line-breaks, and normalized whitespace
* Require global strict mode everywhere
* Require JSDoc for all functions, methods, and classes
