### PR TITLE
why would we allow undefined components in JSX?

### DIFF
--- a/rules/react.js
+++ b/rules/react.js
@@ -27,7 +27,7 @@ module.exports = {
     }],
     'react/jsx-no-duplicate-props': 2,
     'react/jsx-no-target-blank': 2,
-    'react/jsx-no-undef': 1,
+    'react/jsx-no-undef': 2,
     'react/jsx-sort-props': [2, {
       ignoreCase: true
     }],


### PR DESCRIPTION
I'm just wondering if there's a reason this is a warning, not an error?