### PR TITLE
make jsdoc rules enforce type preference

### DIFF
--- a/rules/errors.js
+++ b/rules/errors.js
@@ -9,8 +9,11 @@ module.exports = {
         array: 'Array',
         Boolean: 'boolean',
         Function: 'function',
+        map: 'Map',
         Number: 'number',
         object: 'Object',
+        promise: 'Promise',
+        set: 'Set',
         String: 'string'
       },
       requireReturn: false,

--- a/rules/errors.js
+++ b/rules/errors.js
@@ -5,6 +5,14 @@ module.exports = {
     'comma-dangle': [2, 'never'],
     'no-invalid-regexp': 2,
     'valid-jsdoc': [1, {
+      preferType: {
+        array: 'Array',
+        Boolean: 'boolean',
+        Function: 'function',
+        Number: 'number',
+        object: 'Object',
+        String: 'string'
+      },
       requireReturn: false,
       requireParamDescription: false,
       requireReturnDescription: false


### PR DESCRIPTION
this is inspired by a comment you @tquetano-r7  made here, cuz i'm not gonna remember: 
https://codereview.tor.rapid7.com/cru/CR-5841#CFR-136346

more info here: http://eslint.org/docs/rules/valid-jsdoc#prefertype