### PR TITLE
Updated peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
   "name": "eslint-config-rapid7",
   "optionalDependencies": {},
   "peerDependencies": {
-    "eslint": "^3.0.0 || ^4.0.0"
+    "eslint": "^4.19.1"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
The new rules requires a later version of `eslint` so updating the `peerDependencies` to account for that.