### PR TITLE
Fix: React version not specified warning

### DIFF
--- a/rules/react.js
+++ b/rules/react.js
@@ -5,6 +5,11 @@ module.exports = {
       jsx: true,
     },
   },
+  settings: {
+    react: {
+      version: 'detect'
+    }
+  },
   rules: {
     'jsx-quotes': [2, 'prefer-double'],
 


### PR DESCRIPTION
This fixes the "Warning: React version not specified in eslint-plugin-react settings." that shows up in React projects. See https://github.com/yannickcr/eslint-plugin-react#configuration for the fix.